### PR TITLE
deleted __all__ in repo init

### DIFF
--- a/app/repositories/__init__.py
+++ b/app/repositories/__init__.py
@@ -3,6 +3,3 @@ from app.models.base import Base
 
 
 ModelType = TypeVar("ModelType", bound=Base)
-
-
-__all__ = ["ModelType"]


### PR DESCRIPTION
all это имя которое хранит имена, которые будут импортироваться в записи "from package import *". Я считаю, что использование * - плохая привычка, так как это не явное использование имен, поэтому удалил (не использовал на самом деле даже)