### PR TITLE
added job to ci

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -3,14 +3,16 @@ name: CI Workflow
 on:
   push:
     branches:
-      - develop
+      - '**'
   pull_request:
     branches:
       - develop
 
 jobs:
-  test:
+  api-tests-only:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+
     services:
       postgres:
         image: postgres:16
@@ -20,11 +22,11 @@ jobs:
           POSTGRES_DB: postgres
         ports:
           - 5432:5432
-        options: >-  
-          --health-cmd "pg_isready -U postgres -d postgres"  
-          --health-interval 10s  
-          --health-timeout 5s  
-          --health-retries 5  
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     env:
       APP_NAME: "Task Management API"
@@ -49,20 +51,80 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Ожидание PostgreSQL
-        run: |  
-          for i in {1..10}; do  
-            pg_isready -h localhost -p 5432 && echo "DB is ready" && exit 0  
-            echo "Waiting for DB..."  
-            sleep 3  
-          done  
-          echo "DB did not become available in time" && exit 1  
+        run: |
+          for i in {1..10}; do
+            pg_isready -h localhost -p 5432 && echo "DB is ready" && exit 0
+            echo "Waiting for DB..."
+            sleep 3
+          done
+          echo "DB did not become available in time" && exit 1
 
       - name: Применение миграций
         env:
           SYNC_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
         run: alembic upgrade head
 
-      - name: Запуск тестов
+      - name: Запуск API-тестов
+        env:
+          DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/postgres
+        run: pytest -vv tests/test_api.py
+
+  all-tests:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      APP_NAME: "Task Management API"
+      API_V1_STR: "/api/v1"
+      ASYNC_DATABASE_URL: "postgresql+asyncpg://postgres:postgres@localhost:5432/postgres"
+      DESCRIPTION: "API for managing tasks and users"
+      DEBUG: False
+      APP_HOST_PORT: 8080
+      MODE: TEST
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Установка Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Установка зависимостей
+        run: pip install -r requirements.txt
+
+      - name: Ожидание PostgreSQL
+        run: |
+          for i in {1..10}; do
+            pg_isready -h localhost -p 5432 && echo "DB is ready" && exit 0
+            echo "Waiting for DB..."
+            sleep 3
+          done
+          echo "DB did not become available in time" && exit 1
+
+      - name: Применение миграций
+        env:
+          SYNC_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+        run: alembic upgrade head
+
+      - name: Запуск всех тестов
         env:
           DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/postgres
         run: pytest -vv


### PR DESCRIPTION
Я сделал так, что ci теперь работает так:
При любом пуше производятся тесты апи
При пуллрике в develop производится запуск вообще всех тестов в целом

Я подумал, что это тестировать апи для каждого push повысит надежность и не будет занимать слишком много времени, потому что, когда будет 15млн тестов интеграционных/модульных, то  мы будем их скипать. Однако когда пуллрик в develop, думается, это очень ответственно, и лушче пусть прогонятся все тесты